### PR TITLE
Make valid_time field timezone aware (same as the timestamps from SMHI)

### DIFF
--- a/smhi/smhi_lib.py
+++ b/smhi/smhi_lib.py
@@ -3,6 +3,7 @@ Module smhi_lib contains the code to get forecasts from
 the Swedish weather institute (SMHI) through the open
 API:s
 """
+
 import abc
 import copy
 import json
@@ -389,7 +390,7 @@ def _get_all_forecast_from_api(api_result: dict) -> OrderedDict:
 
     # Get the parameters
     for forecast in api_result["timeSeries"]:
-        valid_time = datetime.strptime(forecast["validTime"], "%Y-%m-%dT%H:%M:%SZ")
+        valid_time = datetime.strptime(forecast["validTime"], "%Y-%m-%dT%H:%M:%S%z")
         for param in forecast["parameters"]:
             if param["name"] == "t":
                 temperature = float(param["values"][0])  # Celcisus

--- a/smhi/test_smhi_lib.py
+++ b/smhi/test_smhi_lib.py
@@ -1,10 +1,11 @@
 """
     Automatic tests for the smhi_lib
 """
+
 # pylint: disable=C0302,W0621,R0903, W0212
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Any, Dict
 
 import aiohttp
@@ -172,7 +173,9 @@ def test_symbol(first_smhi_forecast):
 
 def test_valid_time(first_smhi_forecast):
     """test"""
-    assert first_smhi_forecast.valid_time == datetime(2018, 9, 1, 15, 0, 0)
+    assert first_smhi_forecast.valid_time == datetime(
+        2018, 9, 1, 15, 0, 0, tzinfo=timezone.utc
+    )
 
 
 def test_cloudiness_when_inconclusive(first_smhi_forecast2):


### PR DESCRIPTION
This is a fix to #16

A little note. It would be possible to make the change a bit nicer with `datetime.fromisoformat(forecast["validTime"])` but that would require python 3.11 or later as the variant of ISO8601 timestamps which SMHI is using did not get supported by `fromisoformat` until 3.11, https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat. 