### PR TITLE
remove extraneous "mock" requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp
 black
 coverage
 flake8
-mock
 pyflakes
 pylint
 pytest


### PR DESCRIPTION
If some day in the future you need `mock`, just use `unittest.mock`: it's the same modul that was bolted inside the Python Standard Library years ago. Greetings